### PR TITLE
std89 compliance:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ CC = clang
 #CC = gcc
 
 # compile flags
-CC_FLAGS = -Werror -Wextra -Wall
+CC_FLAGS = -Werror -Wextra -Wall -pedantic -std=c89
 
 # debugging or optimilization flags
 CC_OPT_FLAGS = -Ofast													\

--- a/inc/ft_dtoa_sc.h
+++ b/inc/ft_dtoa_sc.h
@@ -17,6 +17,25 @@
 # define DTOA_MAX_PRECISION 100
 
 /*
+** C89 doesn't define longlong's (introduced in C99)
+*/
+#ifndef C89_LONGLONG
+# define C89_LONGLONG
+
+typedef uint64_t	unsignedlonglong;
+typedef int64_t		longlong;
+#undef  LLONG_MIN
+#undef  LLONG_MAX
+#undef  ULLONG_MAX
+#undef __LONG_LONG_MAX__
+
+#define __LONG_LONG_MAX__ sizeof(int64_t)
+#define LLONG_MAX  __LONG_LONG_MAX__
+#define LLONG_MIN  (-__LONG_LONG_MAX__-1)
+#define ULLONG_MAX (__LONG_LONG_MAX__*2+1)
+#endif
+
+/*
 ** ft_dtoa_sc (put in a separate header because of norminette
 ** (these would be private/static functions irl)
 */
@@ -24,7 +43,7 @@ void		ft_perform_bankers_rounding_sc(double nb, char *worker,
 				size_t worker_len);
 void		ft_perform_retrospective_rounding_sc(char *worker,
 				size_t worker_len, char *master);
-void		ft_handle_integer_rounding_sc(unsigned long long nb_asint,
+void		ft_handle_integer_rounding_sc(unsignedlonglong nb_asint,
 				char *master);
 void		ft_handle_rounding_sc(double nb, char *worker, char *master);
 void		ft_handle_precision_sc(double *nb, int precision,

--- a/inc/ft_ldtoa.h
+++ b/inc/ft_ldtoa.h
@@ -17,6 +17,25 @@
 # define DTOA_MAX_PRECISION 100
 
 /*
+** C89 doesn't define longlong's (introduced in C99)
+*/
+#ifndef C89_LONGLONG
+# define C89_LONGLONG
+
+typedef uint64_t	unsignedlonglong;
+typedef int64_t		longlong;
+#undef  LLONG_MIN
+#undef  LLONG_MAX
+#undef  ULLONG_MAX
+#undef __LONG_LONG_MAX__
+
+#define __LONG_LONG_MAX__ sizeof(int64_t)
+#define LLONG_MAX  __LONG_LONG_MAX__
+#define LLONG_MIN  (-__LONG_LONG_MAX__-1)
+#define ULLONG_MAX (__LONG_LONG_MAX__*2+1)
+#endif
+
+/*
 ** ft_ldtoa2.c (put in a separate header because of norminette
 ** (these would be private/static functions irl)
 */
@@ -24,7 +43,7 @@ void	ft_perform_bankers_rounding(long double nb, char *worker,
 			size_t worker_len);
 void	ft_perform_retrospective_rounding(char *worker,
 			size_t worker_len, char *master);
-void	ft_handle_integer_rounding(unsigned long long nb_asint,
+void	ft_handle_integer_rounding(unsignedlonglong nb_asint,
 			char *master);
 void	ft_handle_rounding(long double nb, char *worker, char *master);
 

--- a/inc/libft.h
+++ b/inc/libft.h
@@ -61,8 +61,29 @@ typedef enum		e_case
 }					t_case;
 
 /*
+** C89 doesn't define longlong's (introduced in C99)
+*/
+#ifndef C89_LONGLONG
+# define C89_LONGLONG
+
+typedef uint64_t	unsignedlonglong;
+typedef int64_t		longlong;
+
+#undef  LLONG_MIN
+#undef  LLONG_MAX
+#undef  ULLONG_MAX
+#undef __LONG_LONG_MAX__
+
+#define __LONG_LONG_MAX__ sizeof(int64_t)
+#define LLONG_MAX  __LONG_LONG_MAX__
+#define LLONG_MIN  (-__LONG_LONG_MAX__-1)
+#define ULLONG_MAX (__LONG_LONG_MAX__*2+1)
+#endif
+
+/*
 **  libft functions
 */
+
 int					ft_islower(int c);
 int					ft_isupper(int c);
 int					ft_isalnum(int c);
@@ -86,13 +107,13 @@ char				*ft_strtok(char *str, const char *delim);
 char				*ft_strstring(const char *str);
 size_t				ft_strstringlen(const char *str);
 long				ft_strtol(const char *str, char **endptr, int base);
-unsigned long long	ft_strtoull(const char *str, char **endptr, int base);
+unsignedlonglong	ft_strtoull(const char *str, char **endptr, int base);
 char				*ft_itoa(int n);
 char				*ft_ultoa_base(unsigned long nb, int base, int uppercase);
-char				*ft_ulltoa_base(unsigned long long nb, int base,
+char				*ft_ulltoa_base(unsignedlonglong nb, int base,
 						int uppercase);
 char				*ft_ltoa_base(long int nb, int base, int uppercase);
-char				*ft_lltoa_base(long long int nb, int base, int uppercase);
+char				*ft_lltoa_base(longlong nb, int base, int uppercase);
 char				*ft_ldtoa(long double nb, int precision);
 char				*ft_dtoa_sc(double nb, int precision, int *exp_ptr,
 						t_bool uppercase);
@@ -100,10 +121,8 @@ char				*ft_dtoa_sc(double nb, int precision, int *exp_ptr,
 char				*ft_strtolower(char *s);
 char				*ft_strtoupper(char *s);
 char				*ft_strchr(const char *s, int c);
-size_t				ft_strlcat(char *dst,
-						const char *src, size_t dstsize);
-size_t				ft_strlcpy(char *restrict dst,
-						const char *restrict src, size_t dstsize);
+size_t				ft_strlcat(char *dst, const char *src, size_t dstsize);
+size_t				ft_strlcpy(char *dst, const char *src, size_t dstsize);
 size_t				ft_strlen(const char *s);
 size_t				ft_wcslen(wchar_t *ws);
 int					ft_wclen(wchar_t wc);
@@ -157,22 +176,22 @@ void				*ft_destroy_array(void **elements, int elem_size,
 /*
 ** basic list functionality
 */
-typedef struct		s_list t_list;
-typedef struct		s_list
+struct				t_list;
+struct				t_list
 {
 	void			*subject;
-	t_list			*next;
-	t_list			*prev;
-}					t_list;
+	struct t_list	*next;
+	struct t_list	*prev;
+};
 
-t_list				*lst_addback(t_list **root, void *subject);
-t_list				*lst_addfront(t_list **root, void *subject);
-t_list				*lst_peekback(t_list *root);
-t_list				*lst_peekfront(t_list *root);
-t_list				*lst_popback(t_list *root, uint8_t is_malloced);
-t_list				*lst_popfront(t_list *root, uint8_t is_malloced);
-t_list				*lst_destroy_item(t_list *root, uint8_t is_malloced);
-t_list				*lst_destroy(t_list **root, uint8_t is_malloced);
+struct t_list				*lst_addback(struct t_list **root, void *subject);
+struct t_list				*lst_addfront(struct t_list **root, void *subject);
+struct t_list				*lst_peekback(struct t_list *root);
+struct t_list				*lst_peekfront(struct t_list *root);
+struct t_list				*lst_popback(struct t_list *root, uint8_t is_malloced);
+struct t_list				*lst_popfront(struct t_list *root, uint8_t is_malloced);
+struct t_list				*lst_destroy_item(struct t_list *root, uint8_t is_malloced);
+struct t_list				*lst_destroy(struct t_list **root, uint8_t is_malloced);
 
 /*
 ** very basic vector implementation, kept in for compatibility with old projects

--- a/src/ft_dtoa_sc1.c
+++ b/src/ft_dtoa_sc1.c
@@ -51,7 +51,7 @@ static void		ft_handle_integer(double *nb, int *exp, char *worker)
 		ft_strlcat(worker, "-", DTOA_WSIZE);
 		*nb *= -1.0;
 	}
-	if (*nb / 10.0 == 0 && (unsigned long long)*nb == 0)
+	if (*nb / 10.0 == 0 && (unsignedlonglong) * nb == 0)
 	{
 		ft_strlcat(worker, "0", DTOA_WSIZE);
 		return ;

--- a/src/ft_dtoa_sc2.c
+++ b/src/ft_dtoa_sc2.c
@@ -23,14 +23,14 @@ void		ft_perform_bankers_rounding_sc(double nb, char *worker,
 				size_t worker_len)
 {
 	int					ctr;
-	unsigned long long	nb_asint;
+	unsignedlonglong	nb_asint;
 
 	ctr = 0;
-	nb_asint = (unsigned long long)nb;
+	nb_asint = (unsignedlonglong)nb;
 	while (ctr < DTOA_MAX_PRECISION)
 	{
 		nb = 10.0 * (nb - nb_asint);
-		nb_asint = (unsigned long long)nb;
+		nb_asint = (unsignedlonglong)nb;
 		if (nb_asint > 0)
 		{
 			worker[worker_len > 0 ? worker_len - 1 : 0]++;
@@ -63,7 +63,7 @@ void		ft_perform_retrospective_rounding_sc(char *worker,
 		worker[worker_len - 1]++;
 }
 
-void		ft_handle_integer_rounding_sc(unsigned long long nb_asint,
+void		ft_handle_integer_rounding_sc(unsignedlonglong nb_asint,
 				char *master)
 {
 	char *tmp;
@@ -79,12 +79,12 @@ void		ft_handle_integer_rounding_sc(unsigned long long nb_asint,
 
 void		ft_handle_rounding_sc(double nb, char *worker, char *master)
 {
-	unsigned long long	nb_asint;
+	unsignedlonglong	nb_asint;
 	size_t				worker_len;
 
-	nb_asint = (unsigned long long)nb;
+	nb_asint = (unsignedlonglong)nb;
 	nb = 10.0 * (nb - nb_asint);
-	nb_asint = (unsigned long long)nb;
+	nb_asint = (unsignedlonglong)nb;
 	worker_len = ft_strnlen(worker, DTOA_WSIZE);
 	if (worker_len == 0)
 	{
@@ -106,14 +106,14 @@ void		ft_handle_precision_sc(double *nb, int precision,
 					char *worker)
 {
 	int					ctr;
-	unsigned long long	nb_asint;
+	unsignedlonglong	nb_asint;
 
 	ctr = 0;
-	nb_asint = (unsigned long long)*nb;
+	nb_asint = (unsignedlonglong)*nb;
 	while (ctr < precision)
 	{
 		*nb = 10.0 * (*nb - nb_asint);
-		nb_asint = (unsigned long long)*nb;
+		nb_asint = (unsignedlonglong)*nb;
 		worker[ctr] = (char)nb_asint + '0';
 		ctr++;
 	}

--- a/src/ft_ldtoa1.c
+++ b/src/ft_ldtoa1.c
@@ -21,14 +21,14 @@ static void		ft_handle_precision(long double *nb, int precision,
 					char *worker)
 {
 	int					ctr;
-	unsigned long long	nb_asint;
+	unsignedlonglong	nb_asint;
 
 	ctr = 0;
-	nb_asint = (unsigned long long)*nb;
+	nb_asint = (unsignedlonglong)*nb;
 	while (ctr < precision)
 	{
 		*nb = 10.0 * (*nb - nb_asint);
-		nb_asint = (unsigned long long)*nb;
+		nb_asint = (unsignedlonglong)*nb;
 		worker[ctr] = (char)nb_asint + '0';
 		ctr++;
 	}
@@ -60,7 +60,7 @@ static char		*ft_handle_integer(long double *nb)
 		ft_strlcat(worker, "0", DTOA_WSIZE);
 		return (ft_strndup(worker, DTOA_WSIZE));
 	}
-	tmp = ft_ulltoa_base((unsigned long long)*nb, 10, __lowcase);
+	tmp = ft_ulltoa_base((unsignedlonglong)*nb, 10, __lowcase);
 	if (tmp)
 	{
 		ft_strlcat(worker, tmp, DTOA_WSIZE);

--- a/src/ft_ldtoa2.c
+++ b/src/ft_ldtoa2.c
@@ -23,14 +23,14 @@ void		ft_perform_bankers_rounding(long double nb, char *worker,
 						size_t worker_len)
 {
 	int					ctr;
-	unsigned long long	nb_asint;
+	unsignedlonglong	nb_asint;
 
 	ctr = 0;
-	nb_asint = (unsigned long long)nb;
+	nb_asint = (unsignedlonglong)nb;
 	while (ctr < DTOA_MAX_PRECISION)
 	{
 		nb = 10.0 * (nb - nb_asint);
-		nb_asint = (unsigned long long)nb;
+		nb_asint = (unsignedlonglong)nb;
 		if (nb_asint > 0)
 		{
 			worker[worker_len > 0 ? worker_len - 1 : 0]++;
@@ -63,7 +63,7 @@ void		ft_perform_retrospective_rounding(char *worker,
 		worker[worker_len - 1]++;
 }
 
-void		ft_handle_integer_rounding(unsigned long long nb_asint,
+void		ft_handle_integer_rounding(unsignedlonglong nb_asint,
 					char *master)
 {
 	char *tmp;
@@ -79,12 +79,12 @@ void		ft_handle_integer_rounding(unsigned long long nb_asint,
 
 void		ft_handle_rounding(long double nb, char *worker, char *master)
 {
-	unsigned long long	nb_asint;
+	unsignedlonglong	nb_asint;
 	size_t				worker_len;
 
-	nb_asint = (unsigned long long)nb;
+	nb_asint = (unsignedlonglong)nb;
 	nb = 10.0 * (nb - nb_asint);
-	nb_asint = (unsigned long long)nb;
+	nb_asint = (unsignedlonglong)nb;
 	worker_len = ft_strnlen(worker, DTOA_WSIZE);
 	if (worker_len == 0)
 	{

--- a/src/ft_lltoa_base.c
+++ b/src/ft_lltoa_base.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include "libft.h"
 
-char			*ft_lltoa_base(long long int nb, int base, int uppercase)
+char			*ft_lltoa_base(longlong nb, int base, int uppercase)
 {
 	char *str;
 	char *finstr;

--- a/src/ft_memccpy.c
+++ b/src/ft_memccpy.c
@@ -16,10 +16,14 @@
 ** only copy if dst != src
 */
 
-void	*ft_memccpy(void *dst, const void *src, int c, size_t n)
+void	*ft_memccpy(void *dst_, const void *src_, int c, size_t n)
 {
+	unsigned char		*dst;
+	const unsigned char	*src = src_;
+
+	dst = dst_;
 	if (dst == src)
-		return (ft_memchr(dst, c, n) + 1);
+		return ((unsigned char *)ft_memchr(dst, c, n) + 1);
 	else
 		while (n > 0)
 		{

--- a/src/ft_memchr.c
+++ b/src/ft_memchr.c
@@ -12,11 +12,13 @@
 
 #include <stddef.h>
 
-void	*ft_memchr(const void *s, int c, size_t n)
+void	*ft_memchr(const void *s0, int c, size_t n)
 {
+	const unsigned char *s = s0;
+
 	while (n > 0)
 	{
-		if (*(unsigned char *)s == (unsigned char)c)
+		if (*s == (unsigned char)c)
 			return ((void *)s);
 		s++;
 		n--;

--- a/src/ft_memcmp.c
+++ b/src/ft_memcmp.c
@@ -12,8 +12,11 @@
 
 #include <stddef.h>
 
-int		ft_memcmp(const void *s1, const void *s2, size_t n)
+int		ft_memcmp(const void *s1_, const void *s2_, size_t n)
 {
+	const unsigned char *s1 = s1_;
+	const unsigned char *s2 = s2_;
+
 	if (s1 && s1 == s2)
 		return (0);
 	while (n > 0)

--- a/src/ft_memcpy.c
+++ b/src/ft_memcpy.c
@@ -12,15 +12,18 @@
 
 #include <stddef.h>
 
-void	*ft_memcpy(void *dst, const void *src, size_t n)
+void	*ft_memcpy(void *dst_, const void *src_, size_t n)
 {
-	const void		*orig_dst = dst;
+	unsigned char		*dst;
+	const unsigned char	*src = src_;
+	const void			*orig_dst = dst_;
 
+	dst = dst_;
 	if (dst == src)
 		return ((void *)orig_dst);
 	while (n > 0)
 	{
-		*(unsigned char *)dst = *(unsigned char *)src;
+		*dst = *src;
 		n--;
 		dst++;
 		src++;

--- a/src/ft_memmove.c
+++ b/src/ft_memmove.c
@@ -12,10 +12,13 @@
 
 #include "libft.h"
 
-static void	*ft_memcpy_rev(void *dst, const void *src, size_t len)
+static void	*ft_memcpy_rev(void *dst_, const void *src_, size_t len)
 {
-	const void		*orig_dst = dst;
+	unsigned char		*dst;
+	const unsigned char	*src = src_;
+	const void			*orig_dst = dst_;
 
+	dst = dst_;
 	dst += len - 1;
 	src += len - 1;
 	while (len > 0)

--- a/src/ft_memset.c
+++ b/src/ft_memset.c
@@ -12,13 +12,15 @@
 
 #include <stddef.h>
 
-void	*ft_memset(void *b, int c, size_t len)
+void	*ft_memset(void *b_, int c, size_t len)
 {
-	const void *b_orig = b;
+	unsigned char	*b;
+	const void		*b_orig = b_;
 
+	b = b_;
 	while (len > 0)
 	{
-		*(unsigned char *)b = (unsigned char)c;
+		*b = (unsigned char)c;
 		b++;
 		len--;
 	}

--- a/src/ft_strtoull.c
+++ b/src/ft_strtoull.c
@@ -50,7 +50,7 @@ static int					ft_numeric_value_for_base(char c, int base)
 		return (-1);
 }
 
-static unsigned long long	ft_strtol_handle_overflow(unsigned long long value,
+static unsignedlonglong	ft_strtol_handle_overflow(unsignedlonglong value,
 								char **endptr, int base)
 {
 	if (endptr)
@@ -64,11 +64,11 @@ static unsigned long long	ft_strtol_handle_overflow(unsigned long long value,
 		return (value);
 }
 
-unsigned long long			ft_strtoull(const char *str, char **endptr,
+unsignedlonglong			ft_strtoull(const char *str, char **endptr,
 								int base)
 {
-	unsigned long long	retval;
-	unsigned long long	cutoff;
+	unsignedlonglong	retval;
+	unsignedlonglong	cutoff;
 	int					nbr;
 
 	if (base < 0 || base == 1 || base > 36)

--- a/src/ft_ulltoa_base.c
+++ b/src/ft_ulltoa_base.c
@@ -13,36 +13,36 @@
 #include "libft.h"
 #include <stdlib.h>
 
-static unsigned int	ft_ulltoa_strlen(unsigned long long nb, int base,
+static unsigned int	ft_ulltoa_strlen(unsignedlonglong nb, int base,
 		unsigned int len)
 {
-	if (nb > (unsigned long long)(base - 1))
+	if (nb > (unsignedlonglong)(base - 1))
 		len += ft_ulltoa_strlen(nb / base, base, len);
 	len += 1;
 	return (len);
 }
 
-static void			ft_fill_string_lowcase(char *str, unsigned long long nb,
+static void			ft_fill_string_lowcase(char *str, unsignedlonglong nb,
 						int base, unsigned int index)
 {
 	const char ctab[36] = "0123456789abcdefghijklmnopqrstuvwxyz";
 
-	if (nb > (unsigned long long)(base - 1))
+	if (nb > (unsignedlonglong)(base - 1))
 		ft_fill_string_lowcase(str, nb / base, base, index - 1);
 	str[index] = ctab[nb % base];
 }
 
-static void			ft_fill_string_upcase(char *str, unsigned long long nb,
+static void			ft_fill_string_upcase(char *str, unsignedlonglong nb,
 						int base, unsigned int index)
 {
 	const char ctab[36] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-	if (nb > (unsigned long long)(base - 1))
+	if (nb > (unsignedlonglong)(base - 1))
 		ft_fill_string_upcase(str, nb / base, base, index - 1);
 	str[index] = ctab[nb % base];
 }
 
-char				*ft_ulltoa_base(unsigned long long nb, int base,
+char				*ft_ulltoa_base(unsignedlonglong nb, int base,
 						int uppercase)
 {
 	unsigned int	len;

--- a/src/lst_addback.c
+++ b/src/lst_addback.c
@@ -13,12 +13,12 @@
 #include <stdlib.h>
 #include "libft.h"
 
-t_list		*lst_addback(t_list **root, void *subject)
+struct t_list		*lst_addback(struct t_list **root, void *subject)
 {
-	t_list	*head;
-	t_list	*new;
+	struct t_list	*head;
+	struct t_list	*new;
 
-	new = malloc(sizeof(t_list));
+	new = malloc(sizeof(struct t_list));
 	if (new)
 	{
 		new->next = NULL;

--- a/src/lst_addfront.c
+++ b/src/lst_addfront.c
@@ -13,12 +13,12 @@
 #include <stdlib.h>
 #include "libft.h"
 
-t_list		*lst_addfront(t_list **root, void *subject)
+struct t_list		*lst_addfront(struct t_list **root, void *subject)
 {
-	t_list	*new;
-	t_list	*head;
+	struct t_list	*new;
+	struct t_list	*head;
 
-	new = malloc(sizeof(t_list));
+	new = malloc(sizeof(struct t_list));
 	if (new)
 	{
 		new->prev = NULL;

--- a/src/lst_destroy.c
+++ b/src/lst_destroy.c
@@ -12,11 +12,11 @@
 
 #include "libft.h"
 
-t_list		*lst_destroy(t_list **root, uint8_t is_malloced)
+struct t_list		*lst_destroy(struct t_list **root, uint8_t is_malloced)
 {
-	t_list	*head;
-	t_list	*rip;
-	
+	struct t_list	*head;
+	struct t_list	*rip;
+
 	if (!root || !*root)
 		return (NULL);
 	head = (*root)->prev;

--- a/src/lst_destroy_item.c
+++ b/src/lst_destroy_item.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include "libft.h"
 
-t_list		*lst_destroy_item(t_list *root, uint8_t is_malloced)
+struct t_list		*lst_destroy_item(struct t_list *root, uint8_t is_malloced)
 {
 	if (root && is_malloced)
 		free(root->subject);

--- a/src/lst_peekback.c
+++ b/src/lst_peekback.c
@@ -12,7 +12,7 @@
 
 #include "libft.h"
 
-t_list		*list_peekback(t_list *root)
+struct t_list		*list_peekback(struct t_list *root)
 {
 	if (root)
 	{

--- a/src/lst_peekfront.c
+++ b/src/lst_peekfront.c
@@ -12,7 +12,7 @@
 
 #include "libft.h"
 
-t_list		*list_peekfront(t_list *root)
+struct t_list		*list_peekfront(struct t_list *root)
 {
 	if (root)
 	{

--- a/src/lst_popback.c
+++ b/src/lst_popback.c
@@ -12,7 +12,7 @@
 
 #include "libft.h"
 
-t_list		*list_popback(t_list *root, uint8_t is_malloced)
+struct t_list		*list_popback(struct t_list *root, uint8_t is_malloced)
 {
 	if (root)
 	{

--- a/src/lst_popfront.c
+++ b/src/lst_popfront.c
@@ -12,7 +12,7 @@
 
 #include "libft.h"
 
-t_list		*list_popfront(t_list *root, uint8_t is_malloced)
+struct t_list		*list_popfront(struct t_list *root, uint8_t is_malloced)
 {
 	if (root)
 	{


### PR DESCRIPTION
- no pointer arithmetic on void pointers(GNU extension), fixes #2
- (unsigned) long long was not defined (C99 feature), fixes #3
- norminette compliancy for source files